### PR TITLE
check all commits since previous job

### DIFF
--- a/check_puppet_style/managed_script_check_style.sh
+++ b/check_puppet_style/managed_script_check_style.sh
@@ -12,6 +12,8 @@
 #
 # scripts_job_name: Name of the jenkins job which is used to pull this repo into your jenkins environment
 
+[ -n $GIT_PREVIOUS_COMMIT ] || GIT_PREVIOUS_COMMIT='HEAD^'
+
 [ "$EXTRA_PATH" ] && export PATH="$EXTRA_PATH:$PATH";
 
 printenv | sort

--- a/check_puppet_syntax/managed_script_check_puppet_syntax.sh
+++ b/check_puppet_syntax/managed_script_check_puppet_syntax.sh
@@ -5,6 +5,8 @@
 #
 # scripts_job_name: Name of the jenkins job which is used to pull this repo into your jenkins environment
 
+[ -n $GIT_PREVIOUS_COMMIT ] || GIT_PREVIOUS_COMMIT='HEAD^'
+
 [ "$EXTRA_PATH" ] && export PATH="$EXTRA_PATH:$PATH";
 scripts_job_name="scripts/puppet"
 


### PR DESCRIPTION
This fixes the problem where only the last commit is checked even when multiple commits are added since the previous job.
Also added a more efficient way to handle finding changed files, without deleted files.
