### PR TITLE
use different method to set default value for GIT_PREVIOUS_COMMIT

### DIFF
--- a/check_puppet_style/managed_script_check_style.sh
+++ b/check_puppet_style/managed_script_check_style.sh
@@ -12,7 +12,7 @@
 #
 # scripts_job_name: Name of the jenkins job which is used to pull this repo into your jenkins environment
 
-[ -z $GIT_PREVIOUS_COMMIT ] && GIT_PREVIOUS_COMMIT='HEAD^'
+GIT_PREVIOUS_COMMIT="${GIT_PREVIOUS_COMMIT-HEAD^}"
 
 [ "$EXTRA_PATH" ] && export PATH="$EXTRA_PATH:$PATH";
 

--- a/check_puppet_syntax/managed_script_check_puppet_syntax.sh
+++ b/check_puppet_syntax/managed_script_check_puppet_syntax.sh
@@ -5,7 +5,7 @@
 #
 # scripts_job_name: Name of the jenkins job which is used to pull this repo into your jenkins environment
 
-[ -z $GIT_PREVIOUS_COMMIT ] && GIT_PREVIOUS_COMMIT='HEAD^'
+GIT_PREVIOUS_COMMIT="${GIT_PREVIOUS_COMMIT-HEAD^}"
 
 [ "$EXTRA_PATH" ] && export PATH="$EXTRA_PATH:$PATH";
 scripts_job_name="scripts/puppet"


### PR DESCRIPTION
The previous way seems to have been broken.
Still not sure why, unless bash considers an empty string as not empty.

Signed-off-by: Dave Simons dave@inuits.eu
