### PR TITLE
enable pass variable with changed files

### DIFF
--- a/check_puppet_style/managed_script_check_style.sh
+++ b/check_puppet_style/managed_script_check_style.sh
@@ -9,10 +9,15 @@
 #
 # PUPPET_LINT_THREADS, PUPPET_LINT_SKIP_TESTS, PUPPET_LINT_SKIP_EXAMPLES,
 # PUPPET_LINT_BIN, PUPPET_LINT_FAILS_WARNING, PUPPET_LINT_FAILS_ERROR
+#
+# CHANGED_FILES: you can pass the list of files which have to be checked
 
 GIT_PREVIOUS_COMMIT="${GIT_PREVIOUS_COMMIT-HEAD^}"
 
 [ "$EXTRA_PATH" ] && export PATH="$EXTRA_PATH:$PATH";
+
+# you can pass changed files in the variable/parameter CHANGED_FILES
+[ -z "$CHANGED_FILES" ] && CHANGED_FILES=$(git diff --name-only --diff-filter=ACMRTUXB ${GIT_PREVIOUS_COMMIT})
 
 printenv | sort
 
@@ -23,7 +28,7 @@ style_script="$(cd $(dirname "$0"); pwd)/../check_puppet_style/check_puppet_styl
 # Catch the modified .pp manifests, puts them in an array and use that array to peform the puppet-style checks
 declare -a files
 
-for FILE in $(git diff --name-only --diff-filter=ACMRTUXB ${GIT_PREVIOUS_COMMIT} | grep ".pp$");
+for FILE in $(echo $CHANGED_FILES | tr ' ' '\n' | grep ".pp$");
 do
 	files=("${files[@]}" $FILE)
 done
@@ -41,7 +46,7 @@ fi
 # Catch the modified modules, puts them in an array and use that array to peform the puppet-style checks
 declare -a modules
 
-for MODULE in $(git diff --name-only --diff-filter=ACMRTUXB ${GIT_PREVIOUS_COMMIT} | grep "^modules/");
+for MODULE in $(echo $CHANGED_FILES | tr ' ' '\n' | grep "^modules/");
 do
 	modules=("${modules[@]}" $MODULE)
 done

--- a/check_puppet_style/managed_script_check_style.sh
+++ b/check_puppet_style/managed_script_check_style.sh
@@ -17,7 +17,7 @@ GIT_PREVIOUS_COMMIT="${GIT_PREVIOUS_COMMIT-HEAD^}"
 [ "$EXTRA_PATH" ] && export PATH="$EXTRA_PATH:$PATH";
 
 # you can pass changed files in the variable/parameter CHANGED_FILES
-[ -z "$CHANGED_FILES" ] && CHANGED_FILES=$(git diff --name-only --diff-filter=ACMRTUXB ${GIT_PREVIOUS_COMMIT})
+[ -z "$CHANGED_FILES" ] && CHANGED_FILES=$(git diff --name-only --diff-filter=ACMRTUXB HEAD ${GIT_PREVIOUS_COMMIT})
 
 printenv | sort
 

--- a/check_puppet_syntax/JENKINS.md
+++ b/check_puppet_syntax/JENKINS.md
@@ -8,7 +8,7 @@ You can obviously choose the name for the parser and the trend graph.
 
 __Regular Expression:__
 ```
-^PUPPET_SYNTAX[^:]*:(.*):.*(warning|err|Error):\s*(.*)$
+^PUPPET_SYNTAX[^:]*:(.*):.*(warning|Warning|err|Error):\s*(.*)$
 ```
 
 __Mapping Script:__

--- a/check_puppet_syntax/managed_script_check_puppet_syntax.sh
+++ b/check_puppet_syntax/managed_script_check_puppet_syntax.sh
@@ -4,16 +4,20 @@
 # Variables to be set: PUPPET_SYNTAX_THREADS, PUPPET_BIN, ERB_BIN, RUBY_BIN
 #
 # scripts_job_name: Name of the jenkins job which is used to pull this repo into your jenkins environment
+# CHANGED_FILES: you can pass the list of files which have to be checked
 
 [ -n $GIT_PREVIOUS_COMMIT ] || GIT_PREVIOUS_COMMIT='HEAD^'
 
 [ "$EXTRA_PATH" ] && export PATH="$EXTRA_PATH:$PATH";
 scripts_job_name="scripts/puppet"
 
+# you can pass changed files in the variable/parameter CHANGED_FILES
+[ -z "$CHANGED_FILES" ] && CHANGED_FILES=$(git diff --name-only --diff-filter=ACMRTUXB ${GIT_PREVIOUS_COMMIT})
+
 # Catch the modified .pp manifests, puts them in an array and use that array to peform the puppet-syntax checks
 declare -a files
 
-for FILE in $(git diff --name-only --diff-filter=ACMRTUXB ${GIT_PREVIOUS_COMMIT} | grep ".pp$");
+for FILE in $(echo $CHANGED_FILES | tr ' ' '\n' | grep ".pp$");
 do
 	files=("${files[@]}" $FILE)
 done
@@ -31,7 +35,7 @@ fi
 # Catch the modified modules, puts them in an array and use that array to peform the puppet-style checks
 declare -a modules
 
-for MODULE in $(git diff --name-only --diff-filter=ACMRTUXB ${GIT_PREVIOUS_COMMIT} | grep "^modules/");
+for MODULE in $(echo $CHANGED_FILES | tr ' ' '\n' | grep "^modules/");
 do
 	modules=("${modules[@]}" $MODULE)
 done

--- a/check_puppet_syntax/managed_script_check_puppet_syntax.sh
+++ b/check_puppet_syntax/managed_script_check_puppet_syntax.sh
@@ -12,7 +12,7 @@
 scripts_job_name="scripts/puppet"
 
 # you can pass changed files in the variable/parameter CHANGED_FILES
-[ -z "$CHANGED_FILES" ] && CHANGED_FILES=$(git diff --name-only --diff-filter=ACMRTUXB ${GIT_PREVIOUS_COMMIT})
+[ -z "$CHANGED_FILES" ] && CHANGED_FILES=$(git diff --name-only --diff-filter=ACMRTUXB HEAD ${GIT_PREVIOUS_COMMIT})
 
 # Catch the modified .pp manifests, puts them in an array and use that array to peform the puppet-syntax checks
 declare -a files


### PR DESCRIPTION
Our jenkins ignores ".git" folder when creating artifacts and "git diff" doesn't work in the jenkins syntax/style check so I pass the variable with changed files through the pipeline.
